### PR TITLE
Docs: Mark KSystemHacker as legacy and point to KSystemInformer

### DIFF
--- a/KSystemHacker/README.md
+++ b/KSystemHacker/README.md
@@ -1,23 +1,18 @@
-# KSystemHacker (Legacy)
+# KSystemHacker (Deprecated / Legacy)
 
 This directory contains a legacy kernel-mode driver project based on the original Process Hacker (KPH) driver.
 
 ## Status
 
-* **Not used by TaskExplorer releases**
-* **Not packaged or installed** by the official installer
-* Kept in the repository for historical reference and development purposes
+- **Deprecated and not used by TaskExplorer releases**
+- **Not packaged or installed** by the official installer
+- Contains **known vulnerabilities** and should not be used in production
+- Kept only for historical / development reference
 
 ## Current Driver
 
 TaskExplorer now vendors the System Informer stack. The actively used kernel driver is located at:
 
-```
 ProcessHacker/KSystemInformer
-```
 
-and is built and shipped as part of the System Informer integration.
-
-If you are building TaskExplorer from source and looking for the runtime driver, refer to `KSystemInformer` instead of this project.
-
----
+If you are building TaskExplorer from source, use `KSystemInformer` instead of this project.

--- a/KSystemHacker/README.md
+++ b/KSystemHacker/README.md
@@ -1,0 +1,23 @@
+# KSystemHacker (Legacy)
+
+This directory contains a legacy kernel-mode driver project based on the original Process Hacker (KPH) driver.
+
+## Status
+
+* **Not used by TaskExplorer releases**
+* **Not packaged or installed** by the official installer
+* Kept in the repository for historical reference and development purposes
+
+## Current Driver
+
+TaskExplorer now vendors the System Informer stack. The actively used kernel driver is located at:
+
+```
+ProcessHacker/KSystemInformer
+```
+
+and is built and shipped as part of the System Informer integration.
+
+If you are building TaskExplorer from source and looking for the runtime driver, refer to `KSystemInformer` instead of this project.
+
+---


### PR DESCRIPTION
This PR adds a short README to `KSystemHacker/` clarifying that:

- The project is a legacy Process Hacker (KPH) kernel driver

- It is not built, packaged, or shipped in TaskExplorer releases

- The active kernel driver is now `ProcessHacker/KSystemInformer`

This avoids confusion for contributors and users who expect to find `KSystemHacker.sys` in installed builds.